### PR TITLE
(feat) add user auth forms and jwt management

### DIFF
--- a/src/auth/AuthContext.jsx
+++ b/src/auth/AuthContext.jsx
@@ -1,0 +1,2 @@
+import {createContext} from 'react';
+export const AuthContext = createContext();

--- a/src/auth/AuthProvider.jsx
+++ b/src/auth/AuthProvider.jsx
@@ -1,0 +1,21 @@
+import { useEffect , useState} from "react";
+import { AuthContext } from "./AuthContext";
+
+function AuthProvider({ children }) {
+    const [token, setToken] = useState(localStorage.getItem('token') || null);
+
+    function logout() {
+        setToken(null)
+    }
+
+    useEffect(() => {
+        localStorage.setItem('token', token);
+    }, [token]);
+
+    return (
+        <AuthContext.Provider value={{ token, setToken, logout}}>
+            {children}
+        </AuthContext.Provider>
+    );
+    }
+export default AuthProvider;

--- a/src/common/App.jsx
+++ b/src/common/App.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import reactLogo from './../assets/react.svg'
 import viteLogo from '/vite.svg'
 import './App.css'
+import LogoutButton from '../profile/Logout'
 
 function App() {
   const [count, setCount] = useState(0)
@@ -31,6 +32,12 @@ function App() {
       <a href='/welcome'>Ir a User Welcome</a>
       <a href='/instructions'>Ir a Instructions</a>
       <a href='/board'>Ir a Jugar</a>
+      <a href='/login'>Login</a>
+      <a href='/signup'>Registro</a>
+      <a href='/admincheck'>Chequeo Scope Admin</a>
+      <a href='/usercheck'>Chequeo Scope User</a>
+      <br></br>
+      <LogoutButton></LogoutButton>
     </div>
   )
 }

--- a/src/common/Routing.jsx
+++ b/src/common/Routing.jsx
@@ -3,7 +3,11 @@ import App from './App'
 import Instructions from '../game/Instructions'
 import Board from '../game/Board'
 import UserWelcome from '../profile/UserWelcome'
-
+import Login from '../profile/Login'
+import Signup from '../profile/Signup'
+import AdminCheck from '../protected/AdminCheck'
+import UserCheck from '../protected/UserCheck'
+import LogoutButton from '../profile/Logout'
 
 function Routing(){
   return (
@@ -12,7 +16,12 @@ function Routing(){
         <Route path={"/"} element={<App />}/>
         <Route path={"/instructions"} element={<Instructions />}/>
         <Route path={"/welcome"} element={<UserWelcome />}/>
+        <Route path={"/login"} element={<Login />}/>
+        <Route path={"/signup"} element={<Signup />}/>
         <Route path={"/board"} element={<Board />}/>
+        <Route path={"/admincheck"} element={<AdminCheck />}/>
+        <Route path={"/usercheck"} element={<UserCheck />}/>
+
       </Routes>
     </BrowserRouter>
   )

--- a/src/common/main.jsx
+++ b/src/common/main.jsx
@@ -2,9 +2,12 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import './index.css'
 import Routing from './Routing'
+import AuthProvider from '../auth/AuthProvider'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
+  <AuthProvider>
     <Routing />
+  </AuthProvider>
   </React.StrictMode>,
 )

--- a/src/game/Board.jsx
+++ b/src/game/Board.jsx
@@ -1,21 +1,24 @@
 import Card from './Card'
 import './Board.css'
-import React, {createContext, useState, useEffect} from "react";
+import React, {createContext, useContext , useState, useEffect} from "react";
 import axios from 'axios';
+import { AuthContext } from '../auth/AuthContext';
 
 export const GameContext = createContext(null);
 
 export default function Board() {
+  const { token } = useContext(AuthContext);
   const [guess, setGuess] = useState();
   const [cards, setCards] = useState({});
   const [playerName, setPlayerName] = useState("");
 
   // Hacemos la request inicial en el primer render
   useEffect(() => {
+    console.log(`Haciendo el request a ${import.meta.env.VITE_BACKEND_URL}/boards/boardData`);
     axios.get(`${import.meta.env.VITE_BACKEND_URL}/boards/boardData`)
       .then((response) => {
         const data = response.data[0];
-
+        
         const characters = {};
         data.Characters.map((character) => {
           characters[character.id] = character;

--- a/src/profile/Login.css
+++ b/src/profile/Login.css
@@ -1,0 +1,62 @@
+.Login {
+    width: 500px;
+    margin: 0 auto;
+    padding: 20px;
+    border: 1px solid #ddd;
+    border-radius: 5px;
+    box-shadow: 0px 0px 5px 0px rgba(0,0,0,0.1);
+    background-color: #f0faff;
+
+  }
+  
+  .Login form label {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-bottom: 10px;
+  }
+
+  .Login form input[type="text"],
+  .Login form input[type="email"],
+  .Login form input[type="password"] {
+    width: 100%;
+    padding: 10px;
+    margin-bottom: 20px;
+    border: 1px solid #ddd;
+    border-radius: 3px;
+  }
+  
+  .Login form input[type="submit"] {
+    background-color: #1e90ff;
+    color: white;
+    padding: 10px 20px;
+    border: none;
+    border-radius: 3px;
+    cursor: pointer;
+  }
+  
+  .Login form input[type="submit"]:hover {
+    background-color: #187bcd;
+  }
+
+  .error {
+    width: 80%;
+    margin: 10px auto;
+    padding: 10px;
+    border: 1px solid #ff4d4d; /* red */
+    border-radius: 5px;
+    color: #ff4d4d; /* red */
+    background-color: #ffe6e6; /* light red */
+    text-align: center;
+  }
+
+  .successMsg {
+    width: 80%;
+    margin: 10px auto;
+    padding: 10px;
+    border: 1px solid #5cff4d; /* green */
+    border-radius: 5px;
+    color: #2aff86; /* green */
+    background-color: #e9ffe6; /* light green */
+    text-align: center;
+  }

--- a/src/profile/Login.jsx
+++ b/src/profile/Login.jsx
@@ -1,0 +1,69 @@
+import React, { useState, useContext } from 'react';
+import { AuthContext } from '../auth/AuthContext';
+import axios from 'axios';
+import './Login.css';
+
+
+function Login() {
+  const { token, setToken } = useContext(AuthContext);
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState(false);
+  const [msg, setMsg] = useState("");
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+
+    axios.post(`${import.meta.env.VITE_BACKEND_URL}/login`, {
+        email: email,
+        password: password
+      }).then((response) => {
+        console.log('Login successful');
+        setError(false);
+        setMsg("Login exitoso!");
+        // Recibimos el token y lo procesamos
+        const access_token = response.data.access_token;
+        localStorage.setItem('token', access_token);
+        setToken(access_token);
+        console.log("Se seteo el token: ", token);
+      }).catch((error) => {
+        console.error('An error occurred while trying to login:', error);
+        setError(true);// aquí puede haber más lógica para tratar los errores
+      })
+
+  };
+
+
+  return (
+    <div className="Login">
+      {msg.length > 0 && <div className="successMsg"> {msg} </div>}
+
+      {error && <div className="error">Hubo un error con el Login, por favor trata nuevamente.</div>}
+      <form onSubmit={handleSubmit}>
+        <label>
+          Email:
+          <input 
+            type="email" 
+            name="email"
+            value={email}
+            onChange={e => setEmail(e.target.value)}
+            required
+          />
+        </label>
+        <label>
+          Password:
+          <input 
+            type="password" 
+            name="password"
+            value={password}
+            onChange={e => setPassword(e.target.value)}
+            required
+          />
+        </label>
+        <input type="submit" value="Enviar" />
+      </form>
+    </div>
+  );
+}
+
+export default Login;

--- a/src/profile/Logout.jsx
+++ b/src/profile/Logout.jsx
@@ -1,0 +1,24 @@
+import React, {useContext, useState} from 'react';
+import './Login.css';
+import { AuthContext } from '../auth/AuthContext';
+
+const LogoutButton = () => {
+  const {logout} = useContext(AuthContext);
+  const [msg, setMsg] = useState("");
+
+  const handleLogout = () => {
+    logout();
+    setMsg("Has hecho logout con éxito!")
+  }
+
+  return (
+    <>
+        {msg.length > 0 && <div className="successMsg"> {msg} </div>}
+        <button onClick={handleLogout}>
+        Cerrar sesión
+        </button>
+    </>
+  );
+}
+
+export default LogoutButton;

--- a/src/profile/Signup.jsx
+++ b/src/profile/Signup.jsx
@@ -1,0 +1,73 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+import './Login.css'; 
+
+function Signup() {
+  const [username, setUsername] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState(false);
+  const [msg, setMsg] = useState("");
+
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+
+    axios.post(`${import.meta.env.VITE_BACKEND_URL}/signup`, {
+        username: username,
+        email: email,
+        password: password
+      }).then((response) => {
+        console.log('Registro exitoso! Ahora puedes volver y loguearte');
+        setError(false);
+        setMsg('Registro exitoso! Ahora puedes volver y loguearte');
+      }).catch((error) => {      
+      console.error('Ocurrió un error:', error);
+      setError(true); // aquí puede haber más lógica para tratar los errores
+      });
+    }
+
+  return (
+    <div className="Login">
+      {msg.length > 0 && <div className="successMsg"> {msg} </div>}
+
+      {error && <div className="error">Hubo un error con el Registro, por favor trata nuevamente.</div>}
+
+      <form onSubmit={handleSubmit}>
+        <label>
+          Username:
+          <input 
+            type="text" 
+            name="username"
+            value={username}
+            onChange={e => setUsername(e.target.value)}
+            required
+          />
+        </label>
+        <label>
+          Email:
+          <input 
+            type="email" 
+            name="email"
+            value={email}
+            onChange={e => setEmail(e.target.value)}
+            required
+          />
+        </label>
+        <label>
+          Password:
+          <input 
+            type="password" 
+            name="password"
+            value={password}
+            onChange={e => setPassword(e.target.value)}
+            required
+          />
+        </label>
+        <input type="submit" value="Submit" />
+      </form>
+    </div>
+  );
+}
+
+export default Signup;

--- a/src/profile/UserWelcome.jsx
+++ b/src/profile/UserWelcome.jsx
@@ -1,7 +1,6 @@
-import { useState } from "react"
+import { useState, useContext } from "react"
 
 export default function UserWelcome() {
-
   const [nombre, setNombre] = useState(null);
 
   function handleChange(nombre) {

--- a/src/protected/AdminCheck.jsx
+++ b/src/protected/AdminCheck.jsx
@@ -1,0 +1,34 @@
+import React, { useEffect, useState , useContext} from 'react';
+import axios from 'axios';
+import { AuthContext } from '../auth/AuthContext';
+
+const AdminCheck = () => { 
+  const { token } = useContext(AuthContext)
+  const [status, setStatus] = useState(null);
+
+  useEffect(() => {
+    console.log(token);
+    axios({
+      method: 'get',
+      url: `${import.meta.env.VITE_BACKEND_URL}/scope-example/protectedadmin`,
+      headers: {
+        'Authorization': `Bearer ${token}`
+      }
+    })
+      .then(response => {
+        setStatus(response.data.message)
+      })
+      .catch(error => {
+        setStatus(error.message);
+      });
+  }, []);
+
+
+  return (
+    <div>
+      {status}
+    </div>
+  );
+}
+
+export default AdminCheck;

--- a/src/protected/UserCheck.jsx
+++ b/src/protected/UserCheck.jsx
@@ -1,0 +1,35 @@
+import React, { useEffect, useState , useContext} from 'react';
+import axios from 'axios';
+import { AuthContext } from '../auth/AuthContext';
+
+const UserCheck = () => { 
+  const { token } = useContext(AuthContext)
+  const [status, setStatus] = useState(null);
+
+  useEffect(() => {
+    console.log(token);
+    axios({
+      method: 'get',
+      url: `${import.meta.env.VITE_BACKEND_URL}/scope-example/protecteduser`,
+      headers: {
+        'Authorization': `Bearer ${token}`
+      }
+    })
+      .then(response => {
+        console.log(response.data.user)
+        setStatus(response.data.message)
+      })
+      .catch(error => {
+        setStatus(error.message);
+      });
+  }, []);
+
+
+  return (
+    <div>
+      {status}
+    </div>
+  );
+}
+
+export default UserCheck;


### PR DESCRIPTION
# What is this pull request?
Add Login/Signup forms and  JWT management .

# Why?
To manage user session and authentication / authorization in a basic way.

# How did you made this changes?
- Created basic login and signup forms in the /profile folder. 
- Use axios to make the requests.
- Context API and localStorage to manage the JWT (/auth folder).

# Testing
None

# Screenshots
None
